### PR TITLE
Updates container to install Mira from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,16 @@ RUN pip install poetry
 RUN poetry config virtualenvs.create false
 RUN poetry install --no-dev
 
+# Install Mira from `hackathon` branch
+RUN git clone https://github.com/indralab/mira.git /mira
+WORKDIR /mira
+RUN git checkout hackathon
+RUN python -m pip install -e .
+RUN apt-get update && \
+    apt-get install -y graphviz libgraphviz-dev
+RUN python -m pip install -e ."[ode,tests,dkg-client,sbml]"
+WORKDIR /jupyter
+
 # Kernel hast to go in a specific spot
 COPY llmkernel /usr/local/share/jupyter/kernels/llmkernel
 


### PR DESCRIPTION
This installation is a bit hacky as it requires cloning the Mira repo and installing from source. I was not able to install it per the README but this seems to work. 

Verified by:

1. run `make build`
2. run the container (it spins up Jupyter)
3. exec into the container
4. open Python repl
5. run....

```
import sympy
import itertools
from mira.metamodel import *
from mira.modeling import Model
from mira.modeling.askenet.petrinet import AskeNetPetriNetModel
from mira.modeling.viz import GraphicalModel
```

to confirm imports work