### PR TITLE
Remove package version requirements when not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "beaker-kernel>=1.5.3",
+  "beaker-kernel>=1.5.5",
 
   # Project libraries
   "chirho[extras]~=0.2.0",


### PR DESCRIPTION
Have been running in to package dependency conflicts, but realized that many of the libraries that were tightly versioned don't need to be.

Double checked all the libraries and how/where they're used, and this should be safe, and allow much easier dependency resolution in the future.